### PR TITLE
Add weighted sampling to variant selection

### DIFF
--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -12,4 +12,8 @@ class Variant < ApplicationRecord
   def set_project
     self.project = split&.project
   end
+
+  def unweighted?
+    weight.nil?
+  end
 end

--- a/app/schemas/variant_schema.rb
+++ b/app/schemas/variant_schema.rb
@@ -11,6 +11,7 @@ class VariantSchema < ApplicationSchema
     root do |root_object|
       id :split_id, **required
       string :name, **required
+      integer :weight, minimum: 1, maximum: 100
 
       object :value, **required do |value|
         value.additional_properties true

--- a/app/serializers/variant_serializer.rb
+++ b/app/serializers/variant_serializer.rb
@@ -1,5 +1,5 @@
 class VariantSerializer < ApplicationSerializer
-  attributes :name, :value, :split_id
+  attributes :name, :value, :weight, :split_id
   filterable_by :split_id
 
   link(:self){ variant_path object }

--- a/db/migrate/20161108184006_add_weight_to_variants.rb
+++ b/db/migrate/20161108184006_add_weight_to_variants.rb
@@ -1,0 +1,5 @@
+class AddWeightToVariants < ActiveRecord::Migration[5.0]
+  def change
+    add_column :variants, :weight, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161027160354) do
+ActiveRecord::Schema.define(version: 20161108184006) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 20161027160354) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer  "project_id", null: false
+    t.integer  "weight"
     t.index ["project_id"], name: "index_variants_on_project_id", using: :btree
     t.index ["split_id"], name: "index_variants_on_split_id", using: :btree
   end

--- a/docs/split_user_variants.md
+++ b/docs/split_user_variants.md
@@ -73,6 +73,7 @@ The assignment of Variant to a User for a Split
       "value": {
         "description": "Original project description"
       },
+      "weight": 50,
       "split_id": "1"
     },
     "links": {
@@ -149,6 +150,7 @@ The assignment of Variant to a User for a Split
       "value": {
         "description": "Original project description"
       },
+      "weight": 50,
       "split_id": "1"
     },
     "links": {

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -9,10 +9,11 @@ A split variant
 
 #### Attributes
 
-| Attribute | Type   | Description |
-| :-------- | :----- | :---------- |
-| `name`    | String | A descriptive name |
-| `value`   | JSON   | The content |
+| Attribute | Type    | Description |
+| :-------- | :-----  | :---------- |
+| `name`    | String  | A descriptive name |
+| `value`   | JSON    | The content |
+| `weight`  | Integer | The likelihood of selecting (1 - 100) |
 
 Expected `value`s for current split keys:
 
@@ -42,6 +43,7 @@ Expected `value`s for current split keys:
       "value": {
         "description": "Original project description"
       },
+      "weight": 50,
       "split_id": 1
     },
     "links": {
@@ -76,6 +78,7 @@ Expected `value`s for current split keys:
       "value": {
         "description": "Original project description"
       },
+      "weight": 50,
       "split_id": 1
     },
     "links": {
@@ -118,6 +121,11 @@ Expected `value`s for current split keys:
           "properties": {},
           "type": "object",
           "additionalProperties": true
+        },
+        "weight": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
         }
       },
       "type": "object",
@@ -182,6 +190,11 @@ Expected `value`s for current split keys:
           "properties": {},
           "type": "object",
           "additionalProperties": true
+        },
+        "weight": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
         }
       },
       "type": "object",

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -15,6 +15,10 @@ A split variant
 | `value`   | JSON    | The content |
 | `weight`  | Integer | The likelihood of selecting (1 - 100) |
 
+Weighted sampling is optional.
+If variants have `weight`s, they should sum to 100.
+If variants do not have `weight`s, a random selection will be made.
+
 Expected `value`s for current split keys:
 
 - `landing.text`

--- a/spec/schemas/variant_schema_spec.rb
+++ b/spec/schemas/variant_schema_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe VariantSchema, type: :schema do
       with :properties do
         its(:split_id){ is_expected.to eql id_schema }
         its(:name){ is_expected.to eql type: 'string' }
+        its(:weight){ is_expected.to eql type: 'integer', minimum: 1, maximum: 100 }
 
         with :value do
           its(:type){ is_expected.to eql 'object' }

--- a/spec/serializers/variant_serializer_spec.rb
+++ b/spec/serializers/variant_serializer_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe VariantSerializer, type: :serializer do
-  let!(:variant){ create :variant }
+  let!(:variant){ create :variant, weight: 40 }
   let(:json) do
     ActiveModelSerializers::SerializableResource.new(Variant.all).as_json
   end
@@ -23,6 +23,7 @@ RSpec.describe VariantSerializer, type: :serializer do
     subject{ json.dig :data, 0, :attributes }
     its([:name]){ is_expected.to eql variant.name }
     its([:value]){ is_expected.to eql variant.value }
+    its([:weight]){ is_expected.to eql variant.weight }
     its([:split_id]){ is_expected.to eql variant.split_id }
   end
 


### PR DESCRIPTION
Allows for either unweighted (uniform random) or weighted assignment of split variants.