### PR TITLE
Add a split type for classifier FTC visibility

### DIFF
--- a/app/models/concerns/metric_types.rb
+++ b/app/models/concerns/metric_types.rb
@@ -18,6 +18,9 @@ module MetricTypes
     ],
     'subject.first-to-classify' => [
       'classification_created'
+     ],
+    'classifier.first-to-classify.visible' => [
+      'classification_created'
      ]
   }
 

--- a/app/models/concerns/metric_types.rb
+++ b/app/models/concerns/metric_types.rb
@@ -20,6 +20,7 @@ module MetricTypes
       'classification_created'
      ],
     'classifier.first-to-classify.visible' => [
+      'classifier_visited',
       'classification_created'
      ]
   }

--- a/app/models/concerns/metric_types.rb
+++ b/app/models/concerns/metric_types.rb
@@ -19,7 +19,7 @@ module MetricTypes
     'subject.first-to-classify' => [
       'classification_created'
      ],
-    'classifier.first-to-classify.visible' => [
+    'subject.first-to-classify.visible' => [
       'classifier_visited',
       'classification_created'
      ]

--- a/docs/splits.md
+++ b/docs/splits.md
@@ -25,6 +25,7 @@ Supported split keys are currently
 - `'workflow.advance'`
 - `'mini-course.visible'`
 - `'subject.first-to-classify'`
+- `'classifier.first-to-classify.visible'`
 
 ### API
 

--- a/docs/splits.md
+++ b/docs/splits.md
@@ -25,7 +25,7 @@ Supported split keys are currently
 - `'workflow.advance'`
 - `'mini-course.visible'`
 - `'subject.first-to-classify'`
-- `'classifier.first-to-classify.visible'`
+- `'subject.first-to-classify.visible'`
 
 ### API
 

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -31,7 +31,8 @@ Expected `value`s for current split keys:
   - `value: { button: true, auto: true }` (enabled/disabled)
 - `subject.first-to-classify`
   - `value: { message: 'Some text' }`
-
+- `classifier.first-to-classify.visible`
+  - `value: { div: true }` (enabled/disabled)
 ### API
 
 <details>

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -31,7 +31,7 @@ Expected `value`s for current split keys:
   - `value: { button: true, auto: true }` (enabled/disabled)
 - `subject.first-to-classify`
   - `value: { message: 'Some text' }`
-- `classifier.first-to-classify.visible`
+- `subject.first-to-classify.visible`
   - `value: { div: true }` (enabled/disabled)
 ### API
 

--- a/spec/models/split_spec.rb
+++ b/spec/models/split_spec.rb
@@ -182,12 +182,12 @@ RSpec.describe Split, type: :model do
         it{ is_expected.to match_array mini_course_visible_metrics }
       end
 
-      context 'for first to classify subject message' do
+      context 'for first–to-classify message' do
         subject{ subject_first_to_classify.metric_types }
         it{ is_expected.to match_array subject_first_to_classify_metrics }
       end
 
-      context 'for first to classify classifier visiblity' do
+      context 'for first-to-classify message visiblity' do
         subject{ subject_first_to_classify_visible.metric_types }
         it{ is_expected.to match_array subject_first_to_classify_visible_metrics }
       end

--- a/spec/models/split_spec.rb
+++ b/spec/models/split_spec.rb
@@ -188,8 +188,8 @@ RSpec.describe Split, type: :model do
       end
 
       context 'for first to classify classifier visiblity' do
-        subject{ classifier_first_to_classify_visible.metric_types }
-        it{ is_expected.to match_array classifier_first_to_classify_visible_metrics }
+        subject{ subject_first_to_classify_visible.metric_types }
+        it{ is_expected.to match_array subject_first_to_classify_visible_metrics }
       end
     end
   end

--- a/spec/models/split_spec.rb
+++ b/spec/models/split_spec.rb
@@ -182,9 +182,14 @@ RSpec.describe Split, type: :model do
         it{ is_expected.to match_array mini_course_visible_metrics }
       end
 
-      context 'for first to classify subject' do
+      context 'for first to classify subject message' do
         subject{ subject_first_to_classify.metric_types }
         it{ is_expected.to match_array subject_first_to_classify_metrics }
+      end
+
+      context 'for first to classify classifier visiblity' do
+        subject{ classifier_first_to_classify_visible.metric_types }
+        it{ is_expected.to match_array classifier_first_to_classify_visible_metrics }
       end
     end
   end

--- a/spec/support/shared_context_for_metric_types.rb
+++ b/spec/support/shared_context_for_metric_types.rb
@@ -13,5 +13,5 @@ RSpec.shared_context 'a split with metric types' do
   let(:workflow_advance_metrics){ %w(classification_created) }
   let(:mini_course_visible_metrics){ %w(classification_created) }
   let(:subject_first_to_classify_metrics){ %w(classification_created) }
-  let(:subject_first_to_classify_visible){ %w(classification_created classifier_visited) }
+  let(:subject_first_to_classify_visible_metrics){ %w(classification_created classifier_visited) }
 end

--- a/spec/support/shared_context_for_metric_types.rb
+++ b/spec/support/shared_context_for_metric_types.rb
@@ -5,6 +5,7 @@ RSpec.shared_context 'a split with metric types' do
   let(:workflow_advance){ create :split, key: 'workflow.advance' }
   let(:mini_course_visible){ create :split, key: 'mini-course.visible' }
   let(:subject_first_to_classify){ create :split, key: 'subject.first-to-classify' }
+  let(:classifier_first_to_classify_visible){ create :split, key: 'classifier.first-to-classify.visible' }
 
   let(:default_metrics){ [] }
   let(:landing_text_metrics){ %w(classifier_visited classification_created) }
@@ -12,4 +13,5 @@ RSpec.shared_context 'a split with metric types' do
   let(:workflow_advance_metrics){ %w(classification_created) }
   let(:mini_course_visible_metrics){ %w(classification_created) }
   let(:subject_first_to_classify_metrics){ %w(classification_created) }
+  let(:classifier_first_to_classify_visible_metrics){ %w(classification_created) }
 end

--- a/spec/support/shared_context_for_metric_types.rb
+++ b/spec/support/shared_context_for_metric_types.rb
@@ -5,7 +5,7 @@ RSpec.shared_context 'a split with metric types' do
   let(:workflow_advance){ create :split, key: 'workflow.advance' }
   let(:mini_course_visible){ create :split, key: 'mini-course.visible' }
   let(:subject_first_to_classify){ create :split, key: 'subject.first-to-classify' }
-  let(:classifier_first_to_classify_visible){ create :split, key: 'classifier.first-to-classify.visible' }
+  let(:subject_first_to_classify_visible){ create :split, key: 'subject.first-to-classify.visible' }
 
   let(:default_metrics){ [] }
   let(:landing_text_metrics){ %w(classifier_visited classification_created) }
@@ -13,5 +13,5 @@ RSpec.shared_context 'a split with metric types' do
   let(:workflow_advance_metrics){ %w(classification_created) }
   let(:mini_course_visible_metrics){ %w(classification_created) }
   let(:subject_first_to_classify_metrics){ %w(classification_created) }
-  let(:classifier_first_to_classify_visible_metrics){ %w(classification_created classifier_visited) }
+  let(:subject_first_to_classify_visible){ %w(classification_created classifier_visited) }
 end

--- a/spec/support/shared_context_for_metric_types.rb
+++ b/spec/support/shared_context_for_metric_types.rb
@@ -13,5 +13,5 @@ RSpec.shared_context 'a split with metric types' do
   let(:workflow_advance_metrics){ %w(classification_created) }
   let(:mini_course_visible_metrics){ %w(classification_created) }
   let(:subject_first_to_classify_metrics){ %w(classification_created) }
-  let(:classifier_first_to_classify_visible_metrics){ %w(classification_created) }
+  let(:classifier_first_to_classify_visible_metrics){ %w(classification_created classifier_visited) }
 end


### PR DESCRIPTION
Adds a new split type for first-to-classify events in the classifier. This is similar to the existing subject viewer message split, but will allow toggling of banners and the like.

Not sure who to tag on this for review, so I'll throw it to the wind.