### PR TITLE
Kubeify Seven-Ten

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,12 +13,12 @@ pipeline {
       steps {
         script {
           def dockerRepoName = 'zooniverse/seven-ten'
-          def dockerImageName = "${dockerRepoName}:${BRANCH_NAME}"
+          def dockerImageName = "${dockerRepoName}:${GIT_COMMIT}"
           def newImage = docker.build(dockerImageName)
+          newImage.push()
 
           if (BRANCH_NAME == 'master') {
             stage('Update latest tag') {
-              newImage.push()
               newImage.push('latest')
             }
           }
@@ -30,7 +30,7 @@ pipeline {
       when { tag 'production-release' }
       agent any
       steps {
-        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-production.tmpl | kubectl apply --record -f -"
+        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-production.tmpl | kubectl --context azure apply --record -f -"
       }
     }
 
@@ -38,7 +38,7 @@ pipeline {
       when { branch 'master' }
       agent any
       steps {
-        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-staging.tmpl | kubectl apply --record -f -"
+        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-staging.tmpl | kubectl --context azure apply --record -f -"
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,70 @@
+#!groovy
+
+pipeline {
+  agent none
+
+  options {
+    disableConcurrentBuilds()
+  }
+
+  stages {
+    stage('Build Docker image') {
+      agent any
+      steps {
+        script {
+          def dockerRepoName = 'zooniverse/seven-ten'
+          def dockerImageName = "${dockerRepoName}:${BRANCH_NAME}"
+          def newImage = docker.build(dockerImageName)
+
+          if (BRANCH_NAME == 'master') {
+            stage('Update latest tag') {
+              newImage.push()
+              newImage.push('latest')
+            }
+          }
+        }
+      }
+    }
+
+    stage('Deploy production to Kubernetes') {
+      when { tag 'production-release' }
+      agent any
+      steps {
+        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-production.tmpl | kubectl apply --record -f -"
+      }
+    }
+
+    stage('Deploy to staging to Kubernetes') {
+      when { branch 'master' }
+      agent any
+      steps {
+        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-staging.tmpl | kubectl apply --record -f -"
+      }
+    }
+  }
+  post {
+    success {
+      script {
+        if (BRANCH_NAME == 'master' || env.TAG_NAME == 'production-release') {
+          slackSend (
+            color: '#00FF00',
+            message: "SUCCESSFUL: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
+            channel: "#ops"
+          )
+        }
+      }
+    }
+
+    failure {
+      script {
+        if (BRANCH_NAME == 'master' || env.TAG_NAME == 'production-release') {
+          slackSend (
+            color: '#FF0000',
+            message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
+            channel: "#ops"
+          )
+        }
+      }
+    }
+  }
+}

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seven-ten-production-app
+  labels:
+    app: seven-ten-production-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: seven-ten-production-app
+  template:
+    metadata:
+      labels:
+        app: seven-ten-production-app
+    spec:
+      containers:
+        - name: seven-ten-production-app
+          image: zooniverse/seven-ten:__IMAGE_TAG__
+          env:
+            - name: RAILS_ENV
+              value: production
+          volumeMounts:
+            - name: seven-ten-production
+              mountPath: "/rails_app/config/database.yml"
+              subPath: "database"
+              readOnly: true
+            - name: seven-ten-production
+              mountPath: "/rails_app/config/honeybadger.yml"
+              subPath: "honeybadger"
+              readOnly: true
+            - name: seven-ten-production
+              mountPath: "/rails_app/config/newrelic.yml"
+              subPath: "newrelic"
+              readOnly: true
+            - name: seven-ten-production
+              mountPath: "/rails_app/config/redis.yml"
+              subPath: "redis"
+              readOnly: true
+            - name: seven-ten-production
+              mountPath: "/rails_app/config/secrets.yml"
+              subPath: "secrets"
+              readOnly: true
+            - name: seven-ten-production
+              mountPath: "/rails_app/config/sidekiq_admin.yml"
+              subPath: "sidekiq_admin"
+              readOnly: true
+      volumes:
+        - name: seven-ten-production
+          secret:
+            secretName: seven-ten-production
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: seven-ten-production-app
+spec:
+  selector:
+    app: seven-ten-production-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: NodePort

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seven-ten-staging-app
+  labels:
+    app: seven-ten-staging-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: seven-ten-staging-app
+  template:
+    metadata:
+      labels:
+        app: seven-ten-staging-app
+    spec:
+      containers:
+        - name: seven-ten-staging-app
+          image: zooniverse/seven-ten:__IMAGE_TAG__
+          env:
+            - name: RAILS_ENV
+              value: staging
+          volumeMounts:
+            - name: seven-ten-staging
+              mountPath: "/rails_app/config/database.yml"
+              subPath: "database"
+              readOnly: true
+            - name: seven-ten-staging
+              mountPath: "/rails_app/config/honeybadger.yml"
+              subPath: "honeybadger"
+              readOnly: true
+            - name: seven-ten-staging
+              mountPath: "/rails_app/config/newrelic.yml"
+              subPath: "newrelic"
+              readOnly: true
+            - name: seven-ten-staging
+              mountPath: "/rails_app/config/redis.yml"
+              subPath: "redis"
+              readOnly: true
+            - name: seven-ten-staging
+              mountPath: "/rails_app/config/secrets.yml"
+              subPath: "secrets"
+              readOnly: true
+            - name: seven-ten-staging
+              mountPath: "/rails_app/config/sidekiq_admin.yml"
+              subPath: "sidekiq_admin"
+              readOnly: true
+      volumes:
+        - name: seven-ten-staging
+          secret:
+            secretName: seven-ten-staging
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: seven-ten-staging-app
+spec:
+  selector:
+    app: seven-ten-staging-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: NodePort


### PR DESCRIPTION
Adds staging and production templates for kubernetes and a Jenkinsfile to deploy it. This app's configs and secrets are stored in S3 and are loaded into the config dir when the AMI is built. I created staging and production secrets in both the AWS and Azure clusters to store this data, and the templates mount them to a file.

The secret looks like this:

```
apiVersion: v1
data:
  database: snip
  honeybadger: snip
  newrelic: snip
  redis: snip
  secrets: snip
  sidekiq_admin: snip
kind: Secret
```

..while the template mounts them like this:

```
          volumeMounts:
            - name: seven-ten-staging
              mountPath: "/rails_app/config/database.yml"
              subPath: "database"
              readOnly: true
```

The containers build locally and I can run a rails console from within them.