### PR TITLE
Update Travis and Bundler version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 cache:
   - bundler
 rvm:
-- 2.3.1
+- 2.6.4
 before_script:
   - rename 's/\.yml.travis$/\.yml/' config/*.yml.travis
   - psql -U postgres -c 'create database travis_ci_test;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ before_script:
   - rename 's/\.yml.travis$/\.yml/' config/*.yml.travis
   - psql -U postgres -c 'create database travis_ci_test;'
   - RACK_ENV=test bundle exec rake db:schema:load
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 services:
   - postgresql
 addons:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,4 +297,4 @@ DEPENDENCIES
   webmock (~> 2.1)
 
 BUNDLED WITH
-   1.13.3
+   1.17.3


### PR DESCRIPTION
* Updates `BUNDLED WITH` version to the latest non-2 version (1.17.3). 
* Updates the version of ruby Travis was using from something old to 2.6.4. 

The Dockerfile uses 2.3.1, which should probably be updated so I'll open an issue. This will solve Travis' problem, though, and will indicate whether a ruby version update will need any attention.