### PR TITLE
run sidekiq start script

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -69,6 +69,7 @@ spec:
       containers:
         - name: seven-ten-staging-sidekiq
           image: zooniverse/seven-ten:__IMAGE_TAG__
+          args: ["/rails_app/docker/start_sidekiq.sh"]
           env:
             - name: RAILS_ENV
               value: staging


### PR DESCRIPTION
ensure we start the sidekiq process and not the default api process

visiting https://seven-ten-staging.zooniverse.org/sidekiq/busy shows we have no sidekiq processes running, which means this app isn't working properly