### PR TITLE
change staging & production replica counts to 0

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: seven-ten-production-app
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: seven-ten-production-app
@@ -64,7 +64,7 @@ metadata:
   labels:
     app: seven-ten-production-sidekiq
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: seven-ten-production-sidekiq

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: seven-ten-staging-app
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: seven-ten-staging-app
@@ -64,7 +64,7 @@ metadata:
   labels:
     app: seven-ten-staging-sidekiq
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: seven-ten-staging-sidekiq


### PR DESCRIPTION
set the replica counts to 0 to stop running API & sidekiq pods as they aren't required for any front ends

Longer term once PFE and FEM remove seven ten from their codebases we can delete the k8s resources and archive this repo.